### PR TITLE
[WIP] Add postMessage callback

### DIFF
--- a/src/deposit/views.py
+++ b/src/deposit/views.py
@@ -143,8 +143,10 @@ def interactive_deposit(request):
             )
             transaction.save()
             create_stellar_deposit.delay(transaction.id)
-            # TODO: Use the proposed callback approach.
-            return render(request, "deposit/success.html")
+
+            serializer = TransactionSerializer(transaction)
+            tx_json = json.dumps({"transaction": serializer.data})
+            return render(request, "deposit/success.html", context={"tx_json": tx_json})
     return render(request, "deposit/form.html", {"form": form})
 
 

--- a/src/templates/deposit/success.html
+++ b/src/templates/deposit/success.html
@@ -1,12 +1,27 @@
 <!DOCTYPE html>
 <html>
-
-<head>
+  <head>
     <title>Success</title>
-</head>
+  </head>
 
-<body>
-    <p>Success! You may now close this window.</p>
-</body>
+  <body>
+    <p>
+      Success! You may now close this window. A postMessage has also been
+      published to either window.opener or window.parent.
+    </p>
 
+    <script>
+      var targetWindow, transaction;
+
+      if (window.opener != void 0) {
+        targetWindow = window.opener;
+      } else {
+        targetWindow = window.parent;
+      }
+
+      transaction = JSON.parse('{{ tx_json|safe }}');
+
+      targetWindow.postMessage(transaction, "*");
+    </script>
+  </body>
 </html>


### PR DESCRIPTION
This PR adds a `postMessage` callback on the success.html template. This is kind of a hacky solution, so it would benefit from a few improvement such as:

1. We should check the the `callback` parameter on the view to determine whether we should actually post a message or not
1. I'm not a big fan of serializing things on the Python side, then re-serializing on JavaScript. Is there a better approach?