### PR TITLE
Fix README to reflect the correct setup order

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ This project was built using Pipenv.
 1. Inside the repo's root, install the project's dependencies: `$ pipenv install`
 1. You'll need a `.env` file (or the equivalent env vars defined). We provide a sample one, which you can copy and modify: `$ cp .env.example .env`
 1. Modify the Stellar account in `.env` as below.
-1. Set up the admin user: `$ pipenv run python src/manage.py createsuperuser`. Provide a username, email, and password of your choice.
 1. Run the database migrations: `$ pipenv run python src/manage.py migrate`
+1. Set up the admin user: `$ pipenv run python src/manage.py createsuperuser`. Provide a username, email, and password of your choice.
 1. Run the redis server in the background: `$ redis-server --daemonize yes`
 1. Run celery: `$ pipenv run celery worker --app app --beat --workdir src -l info`
 1. Run the project: `$ pipenv run python src/manage.py runserver`


### PR DESCRIPTION
I was getting a "django.db.utils.OperationalError: no such table: auth_user" error if I didn't run the migrations before the admin user set up.