### PR TITLE
Convert to new POST endpoints

### DIFF
--- a/src/app/settings.py
+++ b/src/app/settings.py
@@ -77,7 +77,7 @@ MIDDLEWARE = [
     "whitenoise.middleware.WhiteNoiseMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
-    # "django.middleware.csrf.CsrfViewMiddleware",
+    "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",

--- a/src/app/settings.py
+++ b/src/app/settings.py
@@ -77,7 +77,7 @@ MIDDLEWARE = [
     "whitenoise.middleware.WhiteNoiseMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
-    "django.middleware.csrf.CsrfViewMiddleware",
+    # "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",

--- a/src/app/urls.py
+++ b/src/app/urls.py
@@ -17,12 +17,12 @@ from django.contrib import admin
 from django.urls import path, include
 
 urlpatterns = [
+    path(".well-known", include("stellartoml.urls")),
     path("admin", admin.site.urls),
     path("info", include("info.urls")),
     path("fee", include("fee.urls")),
     path("", include("transaction.urls")),
-    path("deposit", include("deposit.urls")),
-    path(".well-known", include("stellartoml.urls")),
-    path("withdraw", include("withdraw.urls")),
+    path("", include("deposit.urls")),
+    path("", include("withdraw.urls")),
     path("auth", include("sep10auth.urls")),
 ]

--- a/src/deposit/urls.py
+++ b/src/deposit/urls.py
@@ -1,9 +1,10 @@
 """This module defines the URL patterns for the `/deposit` endpoint."""
 from django.urls import path
 from .views import deposit, interactive_deposit, confirm_transaction
+from django.views.decorators.csrf import csrf_exempt
 
 urlpatterns = [
-    path("transactions/deposit/interactive", deposit),
+    path("transactions/deposit/interactive", csrf_exempt(deposit)),
     path("deposit/interactive_deposit", interactive_deposit, name="interactive_deposit"),
     path("deposit/confirm_transaction", confirm_transaction, name="confirm_transaction"),
 ]

--- a/src/deposit/urls.py
+++ b/src/deposit/urls.py
@@ -3,7 +3,7 @@ from django.urls import path
 from .views import deposit, interactive_deposit, confirm_transaction
 
 urlpatterns = [
-    path("", deposit),
-    path("/interactive_deposit", interactive_deposit, name="interactive_deposit"),
-    path("/confirm_transaction", confirm_transaction, name="confirm_transaction"),
+    path("transactions/deposit/interactive", deposit),
+    path("deposit/interactive_deposit", interactive_deposit, name="interactive_deposit"),
+    path("deposit/confirm_transaction", confirm_transaction, name="confirm_transaction"),
 ]

--- a/src/deposit/views.py
+++ b/src/deposit/views.py
@@ -15,8 +15,6 @@ from django.http import JsonResponse
 from django.shortcuts import render
 from django.urls import reverse
 from django.views.decorators.clickjacking import xframe_options_exempt
-from django.views.decorators.csrf import csrf_exempt
-from rest_framework import status
 from rest_framework.decorators import api_view, renderer_classes
 from rest_framework.renderers import JSONRenderer
 from rest_framework.response import Response
@@ -207,7 +205,6 @@ def interactive_deposit(request):
 
 
 @validate_sep10_token()
-@csrf_exempt
 @api_view(["POST"])
 @renderer_classes([JSONRenderer])
 def deposit(request):

--- a/src/deposit/views.py
+++ b/src/deposit/views.py
@@ -65,11 +65,11 @@ def _construct_more_info_url(request):
 # pass these to the pop-up.
 def _verify_optional_args(request):
     """Verify the optional arguments to `GET /deposit`."""
-    memo_type = request.GET.get("memo_type")
+    memo_type = request.POST.get("memo_type")
     if memo_type and memo_type not in ("text", "id", "hash"):
         return render_error_response("invalid 'memo_type'")
 
-    memo = request.GET.get("memo")
+    memo = request.POST.get("memo")
     if memo_type and not memo:
         return render_error_response("'memo_type' provided with no 'memo'")
 

--- a/src/tests/deposit_test.py
+++ b/src/tests/deposit_test.py
@@ -22,47 +22,46 @@ from transaction.models import Transaction
 from .helpers import mock_check_auth_success, mock_render_error_response, \
     mock_load_not_exist_account
 
+DEPOSIT_PATH = f"/transactions/deposit/interactive"
 HORIZON_SUCCESS_RESPONSE = {"result_xdr": SUCCESS_XDR, "hash": "test_stellar_id"}
-
 
 @pytest.mark.django_db
 @patch("helpers.check_auth", side_effect=mock_check_auth_success)
 def test_deposit_success(mock_check, client, acc1_usd_deposit_transaction_factory):
-    """`GET /deposit` succeeds with no optional arguments."""
+    """`POST /transactions/deposit/interactive` succeeds with no optional arguments."""
     del mock_check
     deposit = acc1_usd_deposit_transaction_factory()
-    response = client.get(
-        f"/deposit?asset_code=USD&account={deposit.stellar_account}", follow=True
+    response = client.post(
+        DEPOSIT_PATH, {"asset_code": "USD", "account": deposit.stellar_account},
     )
     content = json.loads(response.content)
-    assert response.status_code == 403
     assert content["type"] == "interactive_customer_info_needed"
 
 
 @pytest.mark.django_db
 @patch("helpers.check_auth", side_effect=mock_check_auth_success)
 def test_deposit_success_memo(mock_check, client, acc1_usd_deposit_transaction_factory):
-    """`GET /deposit` succeeds with valid `memo` and `memo_type`."""
+    """`POST /transactions/deposit/interactive` succeeds with valid `memo` and `memo_type`."""
     del mock_check
     deposit = acc1_usd_deposit_transaction_factory()
-    response = client.get(
-        f"/deposit?asset_code=USD&account={deposit.stellar_account}&memo=foo&memo_type=text",
+    response = client.post(
+        DEPOSIT_PATH, {"asset_code": "USD", "account": deposit.stellar_account, "memo_type": "text", "memo": "foo"},
         follow=True,
     )
 
     content = json.loads(response.content)
-    assert response.status_code == 403
     assert content["type"] == "interactive_customer_info_needed"
 
 
 @patch("helpers.check_auth", side_effect=mock_check_auth_success)
 def test_deposit_no_params(mock_check, client):
-    """`GET /deposit` fails with no required parameters."""
+    """`POST /transactions/deposit/interactive` fails with no required parameters."""
     # Because this test does not use the database, the changed setting
     # earlier in the file is not persisted when the tests not requiring
     # a database are run. Thus, we set that flag again here.
     del mock_check
-    response = client.get(f"/deposit", follow=True)
+    response = client.post(
+        DEPOSIT_PATH, {}, follow=True)
     content = json.loads(response.content)
 
     assert response.status_code == 400
@@ -71,9 +70,9 @@ def test_deposit_no_params(mock_check, client):
 
 @patch("helpers.check_auth", side_effect=mock_check_auth_success)
 def test_deposit_no_account(mock_check, client):
-    """`GET /deposit` fails with no `account` parameter."""
+    """`POST /transactions/deposit/interactive` fails with no `account` parameter."""
     del mock_check
-    response = client.get(f"/deposit?asset_code=NADA", follow=True)
+    response = client.post(DEPOSIT_PATH, {"asset_code": "NADA"}, follow=True)
     content = json.loads(response.content)
 
     assert response.status_code == 400
@@ -83,10 +82,10 @@ def test_deposit_no_account(mock_check, client):
 @pytest.mark.django_db
 @patch("helpers.check_auth", side_effect=mock_check_auth_success)
 def test_deposit_no_asset(mock_check, client, acc1_usd_deposit_transaction_factory):
-    """`GET /deposit` fails with no `asset_code` parameter."""
+    """`POST /transactions/deposit/interactive` fails with no `asset_code` parameter."""
     del mock_check
     deposit = acc1_usd_deposit_transaction_factory()
-    response = client.get(f"/deposit?account={deposit.stellar_account}", follow=True)
+    response = client.post(DEPOSIT_PATH, {"account": deposit.stellar_account}, follow=True)
     content = json.loads(response.content)
 
     assert response.status_code == 400
@@ -98,11 +97,11 @@ def test_deposit_no_asset(mock_check, client, acc1_usd_deposit_transaction_facto
 def test_deposit_invalid_account(
     mock_check, client, acc1_usd_deposit_transaction_factory
 ):
-    """`GET /deposit` fails with an invalid `account` parameter."""
+    """`POST /transactions/deposit/interactive` fails with an invalid `account` parameter."""
     del mock_check
     acc1_usd_deposit_transaction_factory()
-    response = client.get(
-        f"/deposit?asset_code=USD&account=GBSH7WNSDU5FEIED2JQZIOQPZXREO3YNH2M5DIBE8L2X5OOAGZ7N2QI6",
+    response = client.post(
+        DEPOSIT_PATH, {"asset_code": "USD", "account": "GBSH7WNSDU5FEIED2JQZIOQPZXREO3YNH2M5DIBE8L2X5OOAGZ7N2QI6"},
         follow=True,
     )
     content = json.loads(response.content)
@@ -116,11 +115,11 @@ def test_deposit_invalid_account(
 def test_deposit_invalid_asset(
     mock_check, client, acc1_usd_deposit_transaction_factory
 ):
-    """`GET /deposit` fails with an invalid `asset_code` parameter."""
+    """`POST /transactions/deposit/interactive` fails with an invalid `asset_code` parameter."""
     del mock_check
     deposit = acc1_usd_deposit_transaction_factory()
-    response = client.get(
-        f"/deposit?asset_code=GBP&account={deposit.stellar_account}", follow=True
+    response = client.post(
+        DEPOSIT_PATH, {"asset_code": "GBP", "account": deposit.stellar_account}, follow=True
     )
     content = json.loads(response.content)
 
@@ -133,11 +132,11 @@ def test_deposit_invalid_asset(
 def test_deposit_invalid_memo_type(
     mock_check, client, acc1_usd_deposit_transaction_factory
 ):
-    """`GET /deposit` fails with an invalid `memo_type` optional parameter."""
+    """`POST /transactions/deposit/interactive` fails with an invalid `memo_type` optional parameter."""
     del mock_check
     deposit = acc1_usd_deposit_transaction_factory()
-    response = client.get(
-        f"/deposit?asset_code=USD&account={deposit.stellar_account}&memo_type=test",
+    response = client.post(
+        DEPOSIT_PATH, {"asset_code": "USD", "account": deposit.stellar_account, "memo_type": "test"},
         follow=True,
     )
     content = json.loads(response.content)
@@ -149,15 +148,15 @@ def test_deposit_invalid_memo_type(
 @pytest.mark.django_db
 @patch("helpers.check_auth", side_effect=mock_check_auth_success)
 def test_deposit_no_memo(mock_check, client, acc1_usd_deposit_transaction_factory):
-    """`GET /deposit` fails with a valid `memo_type` and no `memo` provided."""
+    """`POST /transactions/deposit/interactive` fails with a valid `memo_type` and no `memo` provided."""
     del mock_check
     deposit = acc1_usd_deposit_transaction_factory()
-    response = client.get(
-        f"/deposit?asset_code=USD&account={deposit.stellar_account}&memo_type=text",
+    response = client.post(
+        DEPOSIT_PATH, {"asset_code": "USD", "account": deposit.stellar_account, "memo_type": "text"},
         follow=True,
     )
     content = json.loads(response.content)
-
+    print(response)
     assert response.status_code == 400
     assert content == {"error": "'memo_type' provided with no 'memo'"}
 
@@ -165,11 +164,11 @@ def test_deposit_no_memo(mock_check, client, acc1_usd_deposit_transaction_factor
 @pytest.mark.django_db
 @patch("helpers.check_auth", side_effect=mock_check_auth_success)
 def test_deposit_no_memo_type(mock_check, client, acc1_usd_deposit_transaction_factory):
-    """`GET /deposit` fails with a valid `memo` and no `memo_type` provided."""
+    """`POST /transactions/deposit/interactive` fails with a valid `memo` and no `memo_type` provided."""
     del mock_check
     deposit = acc1_usd_deposit_transaction_factory()
-    response = client.get(
-        f"/deposit?asset_code=USD&account={deposit.stellar_account}&memo=text",
+    response = client.post(
+        DEPOSIT_PATH, {"asset_code": "USD", "account": deposit.stellar_account, "memo": "text"},
         follow=True,
     )
     content = json.loads(response.content)
@@ -183,11 +182,11 @@ def test_deposit_no_memo_type(mock_check, client, acc1_usd_deposit_transaction_f
 def test_deposit_invalid_hash_memo(
     mock_check, client, acc1_usd_deposit_transaction_factory
 ):
-    """`GET /deposit` fails with a valid `memo` of incorrect `memo_type` hash."""
+    """`POST /transactions/deposit/interactive` fails with a valid `memo` of incorrect `memo_type` hash."""
     del mock_check
     deposit = acc1_usd_deposit_transaction_factory()
-    response = client.get(
-        f"/deposit?asset_code=USD&account={deposit.stellar_account}&memo=foo&memo_type=hash",
+    response = client.post(
+        DEPOSIT_PATH, {"asset_code": "USD", "account": deposit.stellar_account, "memo_type": "hash", "memo": "foo"},
         follow=True,
     )
     content = json.loads(response.content)
@@ -412,16 +411,16 @@ def test_deposit_interactive_confirm_success(
     acc1_usd_deposit_transaction_factory,
 ):
     """
-    `GET /deposit` and `GET /deposit/interactive_deposit` succeed with valid `account`
+    `POST /transactions/deposit/interactive` and `GET /deposit/interactive_deposit` succeed with valid `account`
     and `asset_code`.
     """
     del mock_check, mock_delay, mock_submit, mock_base_fee
     deposit = acc1_usd_deposit_transaction_factory()
-    response = client.get(
-        f"/deposit?asset_code=USD&account={deposit.stellar_account}", follow=True
+    response = client.post(
+        DEPOSIT_PATH, {"asset_code": "USD", "account": deposit.stellar_account},
+        follow=True
     )
     content = json.loads(response.content)
-    assert response.status_code == 403
     assert content["type"] == "interactive_customer_info_needed"
 
     transaction_id = content["id"]
@@ -505,11 +504,11 @@ def test_deposit_check_trustlines_horizon(
 
     keypair = Keypair.random()
     deposit.stellar_account = keypair.public_key
-    response = client.get(
-        f"/deposit?asset_code=USD&account={deposit.stellar_account}", follow=True
+    response = client.post(
+        DEPOSIT_PATH, {"asset_code": "USD", "account": deposit.stellar_account},
+        follow=True
     )
     content = json.loads(response.content)
-    assert response.status_code == 403
     assert content["type"] == "interactive_customer_info_needed"
 
     # Complete the interactive deposit. The transaction should be set
@@ -583,7 +582,7 @@ def test_deposit_check_trustlines_horizon(
 
 @pytest.mark.django_db
 def test_deposit_authenticated_success(client, acc1_usd_deposit_transaction_factory):
-    """`GET /deposit` succeeds with the SEP 10 authentication flow."""
+    """`POST /transactions/deposit/interactive` succeeds with the SEP 10 authentication flow."""
     client_address = "GDKFNRUATPH4BSZGVFDRBIGZ5QAFILVFRIRYNSQ4UO7V2ZQAPRNL73RI"
     client_seed = "SDKWSBERDHP3SXW5A3LXSI7FWMMO5H7HG33KNYBKWH2HYOXJG2DXQHQY"
     deposit = acc1_usd_deposit_transaction_factory()
@@ -608,24 +607,23 @@ def test_deposit_authenticated_success(client, acc1_usd_deposit_transaction_fact
     assert encoded_jwt
 
     header = {"HTTP_AUTHORIZATION": f"Bearer {encoded_jwt}"}
-    response = client.get(
-        f"/deposit?asset_code=USD&account={deposit.stellar_account}",
+    response = client.post(
+        DEPOSIT_PATH, {"asset_code": "USD", "account": deposit.stellar_account},
         follow=True,
         **header,
     )
     content = json.loads(response.content)
-    assert response.status_code == 403
     assert content["type"] == "interactive_customer_info_needed"
 
 
 @pytest.mark.django_db
 @patch("helpers.render_error_response", side_effect=mock_render_error_response)
 def test_deposit_no_jwt(mock_render, client, acc1_usd_deposit_transaction_factory):
-    """`GET /deposit` fails if a required JWT isn't provided."""
+    """`POST /transactions/deposit/interactive` fails if a required JWT isn't provided."""
     del mock_render
     deposit = acc1_usd_deposit_transaction_factory()
-    response = client.get(
-        f"/deposit?asset_code=USD&account={deposit.stellar_account}&memo=foo&memo_type=text",
+    response = client.post(
+        DEPOSIT_PATH, {"asset_code": "USD", "account": deposit.stellar_account, "memo_type": "text", "memo": "foo"},
         follow=True,
     )
     content = json.loads(response.content)

--- a/src/tests/withdraw_test.py
+++ b/src/tests/withdraw_test.py
@@ -12,6 +12,7 @@ from transaction.models import Transaction
 
 from .helpers import mock_check_auth_success, mock_render_error_response
 
+WITHDRAW_PATH = "/transactions/withdraw/interactive"
 
 @pytest.mark.django_db
 @patch("helpers.check_auth", side_effect=mock_check_auth_success)
@@ -19,9 +20,8 @@ def test_withdraw_success(mock_check, client, acc1_usd_withdrawal_transaction_fa
     """`GET /withdraw` succeeds with no optional arguments."""
     del mock_check
     acc1_usd_withdrawal_transaction_factory()
-    response = client.get(f"/withdraw?asset_code=USD", follow=True)
+    response = client.post(WITHDRAW_PATH, {"asset_code": "USD"}, follow=True)
     content = json.loads(response.content)
-    assert response.status_code == 403
     assert content["type"] == "interactive_customer_info_needed"
 
 
@@ -33,7 +33,7 @@ def test_withdraw_invalid_asset(
     """`GET /withdraw` fails with an invalid asset argument."""
     del mock_check
     acc1_usd_withdrawal_transaction_factory()
-    response = client.get(f"/withdraw?asset_code=ETH", follow=True)
+    response = client.post(WITHDRAW_PATH, {"asset_code": "ETH"}, follow=True)
     content = json.loads(response.content)
     assert response.status_code == 400
     assert content == {"error": "invalid operation for asset ETH"}
@@ -44,7 +44,7 @@ def test_withdraw_invalid_asset(
 def test_withdraw_no_asset(mock_check, client):
     """`GET /withdraw fails with no asset argument."""
     del mock_check
-    response = client.get(f"/withdraw", follow=True)
+    response = client.get(WITHDRAW_PATH, follow=True)
     content = json.loads(response.content)
     assert response.status_code == 400
     assert content == {"error": "'asset_code' is required"}
@@ -122,7 +122,6 @@ def test_withdraw_interactive_failure_no_memotype(
     acc1_usd_withdrawal_transaction_factory()
     response = client.get(f"/withdraw?asset_code=USD", follow=True)
     content = json.loads(response.content)
-    assert response.status_code == 403
     assert content["type"] == "interactive_customer_info_needed"
 
     transaction_id = content["id"]
@@ -151,9 +150,8 @@ def test_withdraw_interactive_failure_incorrect_memotype(
     """
     del mock_check, mock_transactions
     acc1_usd_withdrawal_transaction_factory()
-    response = client.get(f"/withdraw?asset_code=USD", follow=True)
+    response = client.post(WITHDRAW_PATH, {"asset_code": "USD"}, follow=True)
     content = json.loads(response.content)
-    assert response.status_code == 403
     assert content["type"] == "interactive_customer_info_needed"
 
     transaction_id = content["id"]
@@ -182,9 +180,8 @@ def test_withdraw_interactive_failure_no_memo(
     """
     del mock_check, mock_transactions
     acc1_usd_withdrawal_transaction_factory()
-    response = client.get(f"/withdraw?asset_code=USD", follow=True)
+    response = client.post(WITHDRAW_PATH, {"asset_code": "USD"}, follow=True)
     content = json.loads(response.content)
-    assert response.status_code == 403
     assert content["type"] == "interactive_customer_info_needed"
 
     transaction_id = content["id"]
@@ -213,9 +210,8 @@ def test_withdraw_interactive_failure_incorrect_memo(
     """
     del mock_check, mock_transactions
     acc1_usd_withdrawal_transaction_factory()
-    response = client.get(f"/withdraw?asset_code=USD", follow=True)
+    response = client.post(WITHDRAW_PATH, {"asset_code": "USD"}, follow=True)
     content = json.loads(response.content)
-    assert response.status_code == 403
     assert content["type"] == "interactive_customer_info_needed"
 
     transaction_id = content["id"]
@@ -241,9 +237,8 @@ def test_withdraw_interactive_success_transaction_unsuccessful(
     """
     del mock_check
     acc1_usd_withdrawal_transaction_factory()
-    response = client.get(f"/withdraw?asset_code=USD", follow=True)
+    response = client.post(WITHDRAW_PATH, {"asset_code": "USD"}, follow=True)
     content = json.loads(response.content)
-    assert response.status_code == 403
     assert content["type"] == "interactive_customer_info_needed"
 
     transaction_id = content["id"]
@@ -281,9 +276,8 @@ def test_withdraw_interactive_success_transaction_successful(
     """
     del mock_check
     acc1_usd_withdrawal_transaction_factory()
-    response = client.get(f"/withdraw?asset_code=USD", follow=True)
+    response = client.post(WITHDRAW_PATH, {"asset_code": "USD"}, follow=True)
     content = json.loads(response.content)
-    assert response.status_code == 403
     assert content["type"] == "interactive_customer_info_needed"
 
     transaction_id = content["id"]
@@ -338,9 +332,8 @@ def test_withdraw_authenticated_success(
     assert encoded_jwt
 
     header = {"HTTP_AUTHORIZATION": f"Bearer {encoded_jwt}"}
-    response = client.get(f"/withdraw?asset_code=USD", follow=True, **header)
+    response = client.post(WITHDRAW_PATH, {"asset_code": "USD"}, follow=True, **header)
     content = json.loads(response.content)
-    assert response.status_code == 403
     assert content["type"] == "interactive_customer_info_needed"
 
 
@@ -350,7 +343,7 @@ def test_withdraw_no_jwt(mock_render, client, acc1_usd_withdrawal_transaction_fa
     """`GET /withdraw` fails if a required JWT isn't provided."""
     del mock_render
     acc1_usd_withdrawal_transaction_factory()
-    response = client.get(f"/withdraw?asset_code=USD", follow=True)
+    response = client.post(WITHDRAW_PATH, {"asset_code": "USD"}, follow=True)
     content = json.loads(response.content)
     assert response.status_code == 400
     assert content == {"error": "JWT must be passed as 'Authorization' header"}

--- a/src/transaction/management/commands/watch_transactions.py
+++ b/src/transaction/management/commands/watch_transactions.py
@@ -40,6 +40,8 @@ def process_withdrawal(response, transaction):
     Check if a Stellar transaction's memo matches the ID of a database transaction.
     """
     # Validate the Horizon response.
+    import pdb
+    pdb.set_trace()
     try:
         memo_type = response["memo_type"]
         response_memo = response["memo"]

--- a/src/withdraw/urls.py
+++ b/src/withdraw/urls.py
@@ -3,6 +3,6 @@ from django.urls import path
 from .views import withdraw, interactive_withdraw
 
 urlpatterns = [
-    path("/transactions/withdraw/interactive", withdraw),
-    path("/withdraw/interactive_withdraw", interactive_withdraw, name="interactive_withdraw"),
+    path("transactions/withdraw/interactive", withdraw),
+    path("withdraw/interactive_withdraw", interactive_withdraw, name="interactive_withdraw"),
 ]

--- a/src/withdraw/urls.py
+++ b/src/withdraw/urls.py
@@ -3,6 +3,6 @@ from django.urls import path
 from .views import withdraw, interactive_withdraw
 
 urlpatterns = [
-    path("", withdraw),
-    path("/interactive_withdraw", interactive_withdraw, name="interactive_withdraw"),
+    path("/transactions/withdraw/interactive", withdraw),
+    path("/withdraw/interactive_withdraw", interactive_withdraw, name="interactive_withdraw"),
 ]

--- a/src/withdraw/urls.py
+++ b/src/withdraw/urls.py
@@ -1,8 +1,9 @@
 """This module defines the URL patterns for the `/withdraw` endpoint."""
 from django.urls import path
 from .views import withdraw, interactive_withdraw
+from django.views.decorators.csrf import csrf_exempt
 
 urlpatterns = [
-    path("transactions/withdraw/interactive", withdraw),
+    path("transactions/withdraw/interactive", csrf_exempt(withdraw)),
     path("withdraw/interactive_withdraw", interactive_withdraw, name="interactive_withdraw"),
 ]

--- a/src/withdraw/views.py
+++ b/src/withdraw/views.py
@@ -10,8 +10,6 @@ from django.conf import settings
 from django.shortcuts import render
 from django.urls import reverse
 from django.views.decorators.clickjacking import xframe_options_exempt
-from django.views.decorators.csrf import csrf_exempt
-from rest_framework import status
 from rest_framework.decorators import api_view, renderer_classes
 from rest_framework.renderers import JSONRenderer
 from rest_framework.response import Response
@@ -123,7 +121,6 @@ def interactive_withdraw(request):
 
 
 @validate_sep10_token()
-@csrf_exempt
 @api_view(["POST"])
 @renderer_classes([JSONRenderer])
 def withdraw(request):
@@ -146,5 +143,4 @@ def withdraw(request):
     url = _construct_interactive_url(request, asset_code, transaction_id)
     return Response(
         {"type": "interactive_customer_info_needed", "url": url, "id": transaction_id},
-        status=status.HTTP_403_FORBIDDEN,
     )


### PR DESCRIPTION
In https://github.com/stellar/stellar-protocol/pull/438 we change the `/deposit` and `/withdraw` endpoints to new URLs and change them to POST instead of GET for security.  This makes the changes specified in that PR.

Changes `/deposit` to `/transactions/deposit/interactive`
Changes `/withdraw` to `/transactions/withdraw/interactive`
Changes both endpoints to `POST`

Land with https://github.com/stellar/sep24-demo-client/pull/133